### PR TITLE
Fix typo in the haddocks for 'Control.Monad.Catch.mask' ("diabled" -> ...

### DIFF
--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -123,7 +123,7 @@ class Monad m => MonadCatch m where
   -- 'ControlException.catch'.
   catch :: Exception e => m a -> (e -> m a) -> m a
 
-  -- | Runs an action with asynchronous exceptions diabled. The action is
+  -- | Runs an action with asynchronous exceptions disabled. The action is
   -- provided a method for restoring the async. environment to what it was
   -- at the 'mask' call. See "Control.Exception"'s 'ControlException.mask'.
   mask :: ((forall a. m a -> m a) -> m b) -> m b


### PR DESCRIPTION
..."disabled")
