### PR TITLE
Split off MonadMask from MonadCatch.

### DIFF
--- a/src/Control/Monad/Catch/Pure.hs
+++ b/src/Control/Monad/Catch/Pure.hs
@@ -152,6 +152,9 @@ instance Monad m => MonadCatch (CatchT m) where
       Just e' -> runCatchT (c e')
       Nothing -> return (Left e)
     Right a -> return (Right a)
+-- | Note: This instance is only valid if the underlying monad has a single
+-- exit point!
+instance Monad m => MonadMask (CatchT m) where
   mask a = a id
   uninterruptibleMask a = a id
 

--- a/tests/Control/Monad/Catch/Tests.hs
+++ b/tests/Control/Monad/Catch/Tests.hs
@@ -15,6 +15,10 @@ import Data.Data (Data, Typeable)
 
 import Control.Monad.Trans.Identity (IdentityT(..))
 import Control.Monad.Reader (ReaderT(..))
+import Control.Monad.List (ListT(..))
+import Control.Monad.Trans.Maybe (MaybeT(..))
+import Control.Monad.Error (ErrorT(..))
+--import Control.Monad.Cont (ContT(..))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck (Property, once)
@@ -76,6 +80,11 @@ tests = testGroup "Control.Monad.Catch.Tests" $
         , MSpec "StrictWriter.WriterT IO" $ io . fmap tfst . StrictWriter.runWriterT
         , MSpec "LazyRWS.RWST IO" $ \m -> io $ fmap tfst $ LazyRWS.evalRWST m () ()
         , MSpec "StrictRWS.RWST IO" $ \m -> io $ fmap tfst $ StrictRWS.evalRWST m () ()
+
+        , MSpec "ListT IO" $ \m -> io $ fmap (\[x] -> x) (runListT m)
+        , MSpec "MaybeT IO" $ \m -> io $ fmap (maybe undefined id) (runMaybeT m)
+        , MSpec "ErrorT IO" $ \m -> io $ fmap (either error id) (runErrorT m)
+        --, MSpec "ContT IO" $ \m -> io $ runContT m return
 
         , MSpec "CatchT Indentity" $ fromRight . runCatch
         ]


### PR DESCRIPTION
My two biggest concerns with this pull request are:
1. I believe there is no valid `MonadCatch` instance for `ContT`. Am I mistaken?
2. The requirements I've stated for `MonadMask` do not feel rigorous enough. I'm also worried that the statement regarding `f `finally` g` having `g` run even with async exceptions is inaccurate, since with a non-IO base monad, that won't occur. But I'm uncertain of a better way to word it.
