### PR TITLE
Use transformers-compat to always add ExceptT instances for MonadCatch and MonadThrow

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -36,6 +36,7 @@ library
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
     transformers               >= 0.2      && < 0.5,
+    transformers-compat        >= 0.3      && < 0.5,
     mtl                        >= 2.0      && < 2.3
 
   exposed-modules:

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -92,9 +92,7 @@ import Control.Monad.STM (STM)
 import Control.Monad.Trans.List (ListT(..), runListT)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Control.Monad.Trans.Error (ErrorT(..), Error, runErrorT)
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
-#endif
 import Control.Monad.Trans.Cont (ContT)
 import Control.Monad.Trans.Identity
 import Control.Monad.Reader as Reader
@@ -320,14 +318,12 @@ instance (Error e, MonadThrow m) => MonadThrow (ErrorT e m) where
 instance (Error e, MonadCatch m) => MonadCatch (ErrorT e m) where
   catch (ErrorT m) f = ErrorT $ catch m (runErrorT . f)
 
-#if MIN_VERSION_transformers(0,4,0)
 -- | Throws exceptions into the base monad.
 instance MonadThrow m => MonadThrow (ExceptT e m) where
   throwM = lift . throwM
 -- | Catches exceptions from the base monad.
 instance MonadCatch m => MonadCatch (ExceptT e m) where
   catch (ExceptT m) f = ExceptT $ catch m (runExceptT . f)
-#endif
 
 instance MonadThrow m => MonadThrow (ContT r m) where
   throwM = lift . throwM


### PR DESCRIPTION
My reasoning for this change is that the interface of `Control.Monad.Catch` varied depending on what transformers version was picked and this caused compilation failures in other packages when using `transformers-compat`.

It seems to me that conditionally changing the interface of a package like this is incompatible with the PVP.
