### PR TITLE
cabal: tests depend on transformers-compat

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -56,6 +56,7 @@ test-suite exceptions-tests
     base,
     stm,
     transformers,
+    transformers-compat,
     mtl,
     test-framework             >= 0.8      && < 0.9,
     test-framework-quickcheck2 >= 0.3      && < 0.4,


### PR DESCRIPTION
Since 4c329396b8017cf341f84cb3137b9e20a166d49f
closes https://github.com/ekmett/exceptions/issues/40