### PR TITLE
MonadThrow Q instance

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -35,6 +35,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
+    template-haskell           >= 2.2      && < 2.11,
     transformers               >= 0.2      && < 0.5,
     transformers-compat        >= 0.3      && < 0.5,
     mtl                        >= 2.0      && < 2.3

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -93,6 +93,8 @@ import Control.Monad.Trans.Cont (ContT)
 import Control.Monad.Trans.Identity
 import Control.Monad.Reader as Reader
 
+import Language.Haskell.TH.Syntax (Q)
+
 #if __GLASGOW_HASKELL__ < 706
 import Prelude hiding (catch, foldr)
 import Data.Foldable
@@ -183,6 +185,8 @@ instance MonadThrow Maybe where
   throwM _ = Nothing
 instance e ~ SomeException => MonadThrow (Either e) where
   throwM = Left . toException
+instance MonadThrow Q where
+  throwM = fail . show
 
 instance MonadThrow IO where
   throwM = ControlException.throwIO


### PR DESCRIPTION
Template Haskell's `Q` type has a mechanism for aborting a splice's computation by using `fail`. This admits a pretty simple `MonadThrow` instance which shows the `Exception` to `fail`.

Unfortunately, it doesn't appear that Template Haskell is expressive enough for a `MonadCatch` instance, as [`recover`](http://hackage.haskell.org/package/template-haskell-2.10.0.0/docs/Language-Haskell-TH-Syntax.html#v:recover) doesn't provide a way to see which exception was thrown.