### PR TITLE
Transformers5

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -1,6 +1,6 @@
 name:          exceptions
 category:      Control, Exceptions, Monad
-version:       0.8.0.2
+version:       0.8.0.3
 cabal-version: >= 1.8
 license:       BSD3
 license-file:  LICENSE
@@ -36,7 +36,7 @@ library
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
     template-haskell           >= 2.2      && < 2.11,
-    transformers               >= 0.2      && < 0.5,
+    transformers               >= 0.2      && < 0.6,
     transformers-compat        >= 0.3      && < 0.5,
     mtl                        >= 2.0      && < 2.3
 

--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -56,6 +56,7 @@ test-suite exceptions-tests
   build-depends:
     base,
     stm,
+    template-haskell,
     transformers,
     transformers-compat,
     mtl,


### PR DESCRIPTION
Forced transformers to 0.5 and verified that tests pass:

    Dependency transformers ==0.5.0.0: using transformers-0.5.0.0

Note that an update version of `transformers-compat` with bumped `transformers` dependency would have to be published first to hackage. This [commit](https://github.com/ekmett/transformers-compat/commit/80239e88e89fbb2fcfa44b9e02b63be1b00391da) already has the dependency change.