### PR TITLE
Allow building with transformers 0.5 (on GHC 8 RC)

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -36,7 +36,7 @@ library
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
     template-haskell           >= 2.2      && < 2.11,
-    transformers               >= 0.2      && < 0.5,
+    transformers               >= 0.2      && < 0.6,
     transformers-compat        >= 0.3      && < 0.5,
     mtl                        >= 2.0      && < 2.3
 


### PR DESCRIPTION
to build template haskell should be changed either to base > 4.7 && < 5