### PR TITLE
Bump template-haskell version bound for GHC 8

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -35,7 +35,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.11,
+    template-haskell           >= 2.2      && < 2.12,
     transformers               >= 0.2      && < 0.6,
     transformers-compat        >= 0.3      && < 0.5,
     mtl                        >= 2.0      && < 2.3


### PR DESCRIPTION
Tests pass against the new version of TH, we can probably just edit the .cabal file on hackage rather than creating a new release.