### PR TITLE
Add instances for MonadCatch and MonadMask for Either

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+0.8.3
+-----
+* `MonadCatch` and `MonadMask` instances for `Either SomeException`
+
 0.8.1
 -----
 * Support for throwing in the `template-haskell` `Q` monad

--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -1,6 +1,6 @@
 name:          exceptions
 category:      Control, Exceptions, Monad
-version:       0.8.2.1
+version:       0.8.3
 cabal-version: >= 1.8
 license:       BSD3
 license-file:  LICENSE


### PR DESCRIPTION
Came up in a discussion with @bitonic. There's no downside I can see to
the MonadCatch instance. However, the MonadMask instance is a little bit
more controversial, in that it's not actually doing any masking.
However, it's impossible to know that it's not masking the async
exceptions since there are no side-effects from the Either monad.

Of course, by using unsafePerformIO, we could observe the difference,
but I think that's a valid trade-off.

One final argument against MonadMask for Either: it's probably not
terribly useful.