### PR TITLE
Bumped upper version bound for template-haskell

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -35,7 +35,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.13,
+    template-haskell           >= 2.2      && < 2.14,
     transformers               >= 0.2      && < 0.6,
     transformers-compat        >= 0.3      && < 0.6,
     mtl                        >= 2.0      && < 2.3


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). While testing [Agda](https://github.com/agda/agda) with this version of GHC, I got an error related to the versions allowed of template-haskell.

This PR fix this issue.

Blocking https://github.com/agda/agda/issues/2878. 