### PR TITLE
Bump template-haskell upper bound to 2.16

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -44,7 +44,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.15,
+    template-haskell           >= 2.2      && < 2.16,
     transformers               >= 0.2      && < 0.6,
     transformers-compat        >= 0.3      && < 0.7,
     mtl                        >= 2.0      && < 2.3


### PR DESCRIPTION
This allows us to compile with recent GHC HEAD.