### PR TITLE
Make the test suite depend on the library

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -62,15 +62,13 @@ library
 
 test-suite exceptions-tests
   main-is: Tests.hs
-  other-modules:
-    Control.Monad.Catch
-    Control.Monad.Catch.Pure
-    Control.Monad.Catch.Tests
-  hs-source-dirs: src, tests
+  other-modules: Control.Monad.Catch.Tests
+  hs-source-dirs: tests
   ghc-options: -Wall -fwarn-tabs
   type: exitcode-stdio-1.0
   build-depends:
     base,
+    exceptions,
     stm,
     template-haskell,
     transformers,
@@ -80,5 +78,3 @@ test-suite exceptions-tests
     test-framework-hunit       >= 0.3      && < 0.4,
     test-framework-quickcheck2 >= 0.3      && < 0.4,
     QuickCheck                 >= 2.5      && < 2.14
-  if !impl(ghc >= 8.0)
-    build-depends: fail        == 4.9.*


### PR DESCRIPTION
Before, the test suite would rebuild the entirety of the library's source code separately from the library component, which feels wasteful. Since none of the test suite's dependencies depend on `exceptions`, there shouldn't be any reason why we have to do this.