### PR TITLE
`MonadThrow` instance for the strict `ST s` monad.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+0.10.3 [2019.06.x]
+-------------------
+* `MonadThrow` instance for the strict `ST` monad.
+
 0.10.2 [2019.05.02]
 -------------------
 * Allow building with `base-4.13`/`template-haskell-2.15`.

--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -1,6 +1,6 @@
 name:          exceptions
 category:      Control, Exceptions, Monad
-version:       0.10.2
+version:       0.10.3
 cabal-version: >= 1.8
 license:       BSD3
 license-file:  LICENSE

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -86,6 +86,8 @@ import qualified Control.Monad.Trans.State.Lazy as LazyS
 import qualified Control.Monad.Trans.State.Strict as StrictS
 import qualified Control.Monad.Trans.Writer.Lazy as LazyW
 import qualified Control.Monad.Trans.Writer.Strict as StrictW
+import Control.Monad.ST (ST)
+import Control.Monad.ST.Unsafe (unsafeIOToST)
 import Control.Monad.STM (STM)
 import Control.Monad.Trans.List (ListT(..), runListT)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
@@ -334,6 +336,9 @@ instance MonadMask IO where
       throwM e
     c <- release resource (ExitCaseSuccess b)
     return (b, c)
+
+instance MonadThrow (ST s) where
+  throwM = unsafeIOToST . ControlException.throwIO
 
 instance MonadThrow STM where
   throwM = STM.throwSTM


### PR DESCRIPTION
Hey @ekmett, we've briefly discussed this at ZuriHac and you mentioned that you wouldn't mind such an instance, so here is the PR. Let me know if you'd like me to change anything.

We could also potentially add [`MonadCatch (ST RealWorld)`](https://github.com/lehins/exceptions/commit/2a8295f4c6070f37ba3d75e2ec2802ef3fc5b541) and possibly even `MonadMask (ST RealWorld)`, but I am not sure how useful they would be, cause if someone is dealing with `ST RealWorld`, might as well run it in `IO`.