### PR TITLE
Bump template-haskell bound

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -49,7 +49,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.16,
+    template-haskell           >= 2.2      && < 2.17,
     mtl                        >= 2.0      && < 2.3
 
   if !impl(ghc >= 8.0)


### PR DESCRIPTION
This will be necessary for GHC 8.10.