### PR TITLE
gitignore: Ignore GHC-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+
+# GHC
+dist-install
+GNUmakefile
+ghc.mk


### PR DESCRIPTION
Ignore files generated by the GHC build system.