### PR TITLE
Changes for GHC 8.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+
+# GHC
+GNUmakefile
+ghc.mk

--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -49,7 +49,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.16,
+    template-haskell           >= 2.2      && < 2.17,
     mtl                        >= 2.0      && < 2.3
 
   if !impl(ghc >= 8.0)


### PR DESCRIPTION
Unfortunately this will require a merge commit, not a rebase, as GHC's submodule reference already points to this commit.

This branch includes a `template-haskell` bounds bump and `gitignore` change.