### PR TITLE
Allow building with template-haskell-2.17

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -50,7 +50,7 @@ library
   build-depends:
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.17,
+    template-haskell           >= 2.2      && < 2.18,
     mtl                        >= 2.0      && < 2.3
 
   if !impl(ghc >= 8.0)


### PR DESCRIPTION
See https://gitlab.haskell.org/ghc/ghc/issues/17645. None of the API changes in `template-haskell-2.17` affect `exceptions`.