### PR TITLE
Enable TypeOperators to use (~)

### DIFF
--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}


### PR DESCRIPTION
[GHC Proposal #371](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0371-non-magical-eq.md) requires `TypeOperators` to use type equality `a~b`. The following lines are affected:

```
instance e ~ SomeException => MonadThrow (Either e) where
instance e ~ SomeException => MonadCatch (Either e) where
instance e ~ SomeException => MonadMask (Either e) where
```

The fix is to simply enable the extension.