### PR TITLE
RFC: factor out MonadBracket

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -1,6 +1,6 @@
 name:          exceptions
 category:      Control, Exceptions, Monad
-version:       0.10.4
+version:       2.0
 cabal-version: >= 1.10
 license:       BSD3
 license-file:  LICENSE

--- a/src/Control/Monad/Catch/Pure.hs
+++ b/src/Control/Monad/Catch/Pure.hs
@@ -160,6 +160,7 @@ instance Monad m => MonadCatch (CatchT m) where
       Just e' -> runCatchT (c e')
       Nothing -> return (Left e)
     Right a -> return (Right a)
+
 -- | Note: This instance is only valid if the underlying monad has a single
 -- exit point!
 --
@@ -168,6 +169,13 @@ instance Monad m => MonadCatch (CatchT m) where
 instance Monad m => MonadMask (CatchT m) where
   mask a = a id
   uninterruptibleMask a = a id
+
+-- | Note: This instance is only valid if the underlying monad has a single
+-- exit point!
+--
+-- For example, @IO@ or @Either@ would be invalid base monads, but
+-- @Reader@ or @State@ would be acceptable.
+instance Monad m => MonadBracket (CatchT m) where
   generalBracket acquire release use = CatchT $ do
     eresource <- runCatchT acquire
     case eresource of


### PR DESCRIPTION
I think @dcoutts makes a good argument in #69.

In this PR I factored out MonadBracket and tweaked some documentation. The refactor took about 5 minutes, and I didn't have to change any instances. I'm happy with the result.

What do you think?