### PR TITLE
Add `HasCallStack` to classes and functions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.12.1
+# version: 0.14.3
 #
-# REGENDATA ("0.12.1",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.14.3",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -20,71 +20,131 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.2.2
+            compilerKind: ghc
+            compilerVersion: 9.2.2
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.0.2
+            compilerKind: ghc
+            compilerVersion: 8.0.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.10.3
+            compilerKind: ghc
+            compilerVersion: 7.10.3
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.8.4
+            compilerKind: ghc
+            compilerVersion: 7.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.6.3
+            compilerKind: ghc
+            compilerVersion: 7.6.3
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.4.2
+            compilerKind: ghc
+            compilerVersion: 7.4.2
+            setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.2.2
-            allow-failure: true
-          - compiler: ghc-7.0.4
-            allow-failure: true
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y $CC cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          fi
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
-          HCNAME=ghc
-          HC=$HCDIR/bin/$HCNAME
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -106,6 +166,10 @@ jobs:
             prefix: $CABAL_DIR
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
+          EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
           EOF
           cat $CABAL_CONFIG
       - name: versions
@@ -145,7 +209,8 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_exceptions="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/exceptions-[0-9.]*')"
-          echo "PKGDIR_exceptions=${PKGDIR_exceptions}" >> $GITHUB_ENV
+          echo "PKGDIR_exceptions=${PKGDIR_exceptions}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_exceptions}" >> cabal.project

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,6 +1,5 @@
 distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
-allow-failures:         <7.3
 -- irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True

--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -49,7 +49,8 @@ library
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
     template-haskell           >= 2.2      && < 2.20,
-    mtl                        >= 2.0      && < 2.4
+    mtl                        >= 2.0      && < 2.4,
+    call-stack                 >= 0.1      && < 0.5
 
   if !impl(ghc >= 8.0)
     build-depends: fail        == 4.9.*

--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -12,9 +12,7 @@ bug-reports:   http://github.com/ekmett/exceptions/issues
 copyright:     Copyright (C) 2013-2015 Edward A. Kmett
                Copyright (C) 2012 Google Inc.
 build-type:    Simple
-tested-with:   GHC == 7.0.4
-             , GHC == 7.2.2
-             , GHC == 7.4.2
+tested-with:   GHC == 7.4.2
              , GHC == 7.6.3
              , GHC == 7.8.4
              , GHC == 7.10.3
@@ -23,8 +21,9 @@ tested-with:   GHC == 7.0.4
              , GHC == 8.4.4
              , GHC == 8.6.5
              , GHC == 8.8.4
-             , GHC == 8.10.4
-             , GHC == 9.0.1
+             , GHC == 8.10.7
+             , GHC == 9.0.2
+             , GHC == 9.2.2
 synopsis:      Extensible optionally-pure exceptions
 description:   Extensible optionally-pure exceptions.
 
@@ -46,9 +45,9 @@ flag transformers-0-4
 
 library
   build-depends:
-    base                       >= 4.3      && < 5,
+    base                       >= 4.5      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.2      && < 2.20,
+    template-haskell           >= 2.7      && < 2.20,
     mtl                        >= 2.0      && < 2.4
 
   if !impl(ghc >= 8.0)

--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -49,11 +49,11 @@ library
     base                       >= 4.3      && < 5,
     stm                        >= 2.2      && < 3,
     template-haskell           >= 2.2      && < 2.20,
-    mtl                        >= 2.0      && < 2.4,
-    call-stack                 >= 0.1      && < 0.5
+    mtl                        >= 2.0      && < 2.4
 
   if !impl(ghc >= 8.0)
-    build-depends: fail        == 4.9.*
+    build-depends: call-stack  >= 0.1      && < 0.5,
+                   fail        == 4.9.*
 
   if flag(transformers-0-4)
     build-depends:

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -94,7 +94,7 @@ import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Control.Monad.Trans.Cont (ContT)
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Reader (ReaderT(..), runReaderT)
-import GHC.Stack (HasCallStack)
+import Data.CallStack (HasCallStack)
 
 import Language.Haskell.TH.Syntax (Q)
 

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -122,12 +122,17 @@ import Control.Applicative
 #if __GLASGOW_HASKELL__ >= 800
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 #else
-import Data.CallStack (HasCallStack, withFrozenCallStack)
+import Data.CallStack (HasCallStack)
 #endif
 
 #if !(MIN_VERSION_transformers(0,6,0))
 import Control.Monad.Trans.Error (ErrorT(..), Error, runErrorT)
 import Control.Monad.Trans.List (ListT(..), runListT)
+#endif
+
+#if __GLASGOW_HASKELL__ < 800
+withFrozenCallStack :: a -> a
+withFrozenCallStack a = a
 #endif
 
 ------------------------------------------------------------------------------

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -748,33 +748,12 @@ instance MonadCatch m => MonadCatch (ListT m) where
 
 -- | Like 'mask', but does not pass a @restore@ action to the argument.
 mask_ :: (HasCallStack, MonadMask m) => m a -> m a
-mask_ io = mask $ \_ -> io
+mask_ io = withFrozenCallStack (\f -> mask (\x -> f x)) (\_ -> io)
 
 -- | Like 'uninterruptibleMask', but does not pass a @restore@ action to the
 -- argument.
 uninterruptibleMask_ :: (HasCallStack, MonadMask m) => m a -> m a
-uninterruptibleMask_ io = uninterruptibleMask (\_ -> io)
-
--- You may wonder why there isn't a `withFrozenCallStack` on `mask_` and
--- `uninterruptibleMask_`. The reason is that GHC is incapable of unifying
--- the type due to the RankNType in `mask`.
---
--- src/Control/Monad/Catch.hs:746:32: error:
---     • Couldn't match type ‘p1’ with ‘forall a1. m a1 -> m a1’
---       Expected: (forall a1. m a1 -> m a1) -> m a
---         Actual: p1 -> m a
---       Cannot instantiate unification variable ‘p1’
---       with a type involving polytypes: forall a1. m a1 -> m a1
---     • In the first argument of ‘withFrozenCallStack’, namely ‘mask’
---       In the first argument of ‘($)’, namely ‘withFrozenCallStack mask’
---       In the expression: withFrozenCallStack mask $ \ _ -> io
---     • Relevant bindings include
---         io :: m a (bound at src/Control/Monad/Catch.hs:746:7)
---         mask_ :: m a -> m a (bound at src/Control/Monad/Catch.hs:746:1)
---     |
--- 746 | mask_ io = withFrozenCallStack mask $ \_ -> io
---     |                                ^^^^
---
+uninterruptibleMask_ io = withFrozenCallStack (\f -> uninterruptibleMask (\x -> f x)) (\_ -> io)
 
 -- | Catches all exceptions, and somewhat defeats the purpose of the extensible
 -- exception system. Use sparingly.

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -94,7 +94,6 @@ import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Control.Monad.Trans.Cont (ContT)
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Reader (ReaderT(..), runReaderT)
-import Data.CallStack (HasCallStack)
 
 import Language.Haskell.TH.Syntax (Q)
 
@@ -116,6 +115,12 @@ import Data.Monoid
 
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
+
+#if __GLASGOW_HASKELL__ >= 800
+import GHC.Stack (HasCallStack)
+#else
+import Data.CallStack (HasCallStack)
 #endif
 
 #if !(MIN_VERSION_transformers(0,6,0))

--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}


### PR DESCRIPTION
This PR adds `HasCallStack` constraints to the class methods on this library. This allows for callsites to be populated with interesting information. 

The primary use case I can imagine here is supporting [`annotated-exception`](https://hackage.haskell.org/package/annotated-exception-0.2.0.4/docs/Control-Exception-Annotated.html), and allowing you to define an instance of `MonadThrow` that always annotates with callstack:

```haskell
instance MonadThrow AppM where
    throwM = throwWithCallStack
```

With this, anything that uses `throwM` at the `AppM` type gets a call stack on the attached exception.

While this only benefits users of `annotated-exception` currently, when the GHC proposal to [decorate all exceptions with backtrace information](https://github.com/ghc-proposals/ghc-proposals/pull/330) is implemented, then everyone benefits from this.

Without this constraint, the `CallStack` used by the above instance points to the instance definition site - not terribly useful.