### PR TITLE
Allow building with `template-haskell-2.20.*`

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -47,7 +47,7 @@ library
   build-depends:
     base                       >= 4.5      && < 5,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.7      && < 2.20,
+    template-haskell           >= 2.7      && < 2.21,
     mtl                        >= 2.0      && < 2.4
 
   if !impl(ghc >= 8.0)


### PR DESCRIPTION
See https://gitlab.haskell.org/ghc/ghc/issues/22767.