### PR TITLE
test: `cabal test -w ghc-9.4 --constraint="mtl == 2.3.1"`

### DIFF
--- a/tests/Control/Monad/Catch/Tests.hs
+++ b/tests/Control/Monad/Catch/Tests.hs
@@ -40,8 +40,8 @@ import qualified Control.Monad.Writer.Strict as StrictWriter
 import qualified Control.Monad.RWS.Lazy as LazyRWS
 import qualified Control.Monad.RWS.Strict as StrictRWS
 #if !(MIN_VERSION_transformers(0,6,0))
-import Control.Monad.Error (ErrorT(..))
-import Control.Monad.List (ListT(..))
+import Control.Monad.Trans.Error (ErrorT(..))
+import Control.Monad.Trans.List (ListT(..))
 #endif
 
 import Control.Monad.Catch


### PR DESCRIPTION
There were a few places where import availability depended on the mtl version, but was determined by referring to the transformers version, so the CPP macro has been modified to refer to the mtl version.
I really wanted to get rid of the direct dependence on transformers, but since mtl does not export `MaybeT`, etc., I decided it would be difficult to do so.

The way I verified this was by running `cabal test --constraint="mtl == 2.3.1"`
This would not pass before the fix, but it will if you adapt this commit.
