### PR TITLE
Replace reference to ErrorT in module doc with ExceptT

### DIFF
--- a/src/Control/Monad/Catch.hs
+++ b/src/Control/Monad/Catch.hs
@@ -35,7 +35,7 @@
 -- with them, though doesn't mimic the module structure or offer the complete
 -- range of features in those packages.
 --
--- This is very similar to 'ErrorT' and 'MonadError', but based on features of
+-- This is very similar to 'ExceptT' and 'MonadError', but based on features of
 -- "Control.Exception". In particular, it handles the complex case of
 -- asynchronous exceptions by including 'mask' in the typeclass. Note that the
 -- extensible exceptions feature relies on the RankNTypes language extension.


### PR DESCRIPTION
The [documentation at the top of the Control.Monad.Catch module](https://hackage.haskell.org/package/exceptions-0.10.8/docs/Control-Monad-Catch.html) is still referring to `ErrorT`, even though it has been deprecated for a very long time and removed from transformers v0.6.x.x and onwards alltogether.

This PR replaces the mention of `ErrorT` with its non-deprecated replacement `ExceptT`.