### PR TITLE
Bounds bumps for GHC 9.12 and 9.14

### DIFF
--- a/exceptions.cabal
+++ b/exceptions.cabal
@@ -45,7 +45,7 @@ library
     base                       >= 4.9      && < 5,
     mtl                        >= 2.2      && < 2.4,
     stm                        >= 2.2      && < 3,
-    template-haskell           >= 2.11     && < 2.24,
+    template-haskell           >= 2.11     && < 2.25,
     transformers               >= 0.5.2.0  && < 0.7
 
   exposed-modules:


### PR DESCRIPTION
This includes bounds bumps for GHC 9.14 and 9.12.